### PR TITLE
Ajuste Painel Eletronico

### DIFF
--- a/src/apps/painel/scss/painel.scss
+++ b/src/apps/painel/scss/painel.scss
@@ -2,12 +2,15 @@
 .painel-principal {
   background: #1c1b1b;
   font-family: Verdana;
+  font-size: x-large;
   .text-title {
     color: #4fa64d;
     margin: 0.5rem;
+	font-weight: bold;
   }
   .text-subtitle {
     color: #459170;
+	font-weight: bold;
   }
   .data-hora {
     font-size: 180%;


### PR DESCRIPTION
@LeandroJatai fiz um pequeno ajuste no painel para deixar mais nítido para por em TV/Monitor nas sessões plenárias.
e  uma mudança na linha 74 do arquivo sapl/sapl/templates/painel/index.html

 "span id="parlamentares" class="text-value text-center" "

![painel](https://user-images.githubusercontent.com/1524415/52982660-1297f300-33c6-11e9-9315-c86fabfc2571.png)

