### PR TITLE
Adicionando css para padronizar tamanho da fonte de texto não articulado

### DIFF
--- a/src/__apps/compilacao/scss/compilacao.scss
+++ b/src/__apps/compilacao/scss/compilacao.scss
@@ -417,6 +417,12 @@ a:link:after, a:visited:after {
       margin-top: 0.3333em;
       font-size: 1.15em;
     }
+    
+    .texto_n_estruturado{ 
+      margin-top: 0.3333em;
+      font-size: 1.15em;
+    }
+
 
     .paragrafo {
       font-size: 1.1em;


### PR DESCRIPTION
# Descrição
Resolvendo problemas da issue [3190](https://github.com/interlegis/sapl/issues/3190) ticket [412072](https://suporte.interlegis.leg.br/scp/tickets.php?id=36489)
